### PR TITLE
WIP: Implement hooks

### DIFF
--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -197,7 +197,9 @@ _around cache before after spec = modify $ const $
    in groups <#> \group ->
         group <#> \example ->
           \ctx -> do
-            -- TODO: this is not composable but a necessary evil
+            -- XXX: This is kludgy, but necessary in order to share state
+            -- between each example. We expect the runner to pass a fresh ctx
+            -- AVar for each group of tests.
             v /\ ctx' <- unsafeCoerceAff do
               tryPeekVar ctx >>= case _ of
                 Just v -> pure (unsafeCoerce v)
@@ -207,6 +209,9 @@ _around cache before after spec = modify $ const $
                   putVar ctx (unsafeCoerce $ v /\ ctx')
                   pure $ v /\ ctx'
             unsafeCoerceAff $ eval (example ctx') v
+
+            -- TODO: have the runner indicate if this is the last test in this
+            -- group and run the clean up action.
             unsafeCoerceAff $ after v
 
 -- | Run an effectful computation around each test, passing the result to

--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -14,6 +14,7 @@ module Test.Spec (
   itOnly,
   beforeEach,
   afterEach,
+  aroundEach,
   collect,
   countTests,
   class Example,
@@ -172,14 +173,14 @@ itOnly description example = modify (_ <> [It true description example])
 
 -- | Run an effectful computation around each test, passing the result to
 -- | the test and cleaning up afterwards
-around
+aroundEach
   :: ∀ eff1 eff2 eff3 eff4 fun1 fun2 arg1
    . Example eff3 arg1 fun1
   => Aff eff1 arg1
   -> (arg1 -> Aff eff2 Unit)
   -> SpecWith fun1 Unit
   -> Spec eff4 {- eff1 + eff2 + eff3 -} Unit
-around before after spec = modify $ const $
+aroundEach before after spec = modify $ const $
   let groups = collect spec
    in groups <#> \group ->
         group <#> \example -> void do
@@ -196,7 +197,7 @@ beforeEach
   => Aff eff1 arg1
   -> SpecWith fun1 Unit
   -> Spec eff2 {- eff1 + eff2 -} Unit
-beforeEach = flip around (const $ pure unit)
+beforeEach = flip aroundEach (const $ pure unit)
 
 -- | Run an effectful computation beofre each test, passing the result to
 -- | the test
@@ -206,4 +207,4 @@ afterEach
   => Aff eff1 Unit
   -> SpecWith fun1 Unit
   -> Spec eff2 {- eff1 + eff2 -} Unit
-afterEach after = around (pure unit) (const after)
+afterEach after = aroundEach (pure unit) (const after)

--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -12,9 +12,10 @@ module Test.Spec (
   pending',
   it,
   itOnly,
-  -- beforeEach,
-  -- afterEach,
+  beforeEach,
+  afterEach,
   aroundEach,
+  beforeAll,
   collect,
   countTests,
   class Example,
@@ -25,14 +26,16 @@ import Prelude
 import Control.Monad.State as State
 import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
-import Control.Monad.Aff.AVar (AVAR, AVar, peekVar)
+import Control.Monad.Aff.AVar (AVAR, AVar, tryPeekVar, makeVar, putVar)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Aff.Console as Console
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Eff.Timer (TIMER)
 import Control.Monad.State (State, modify, execState, runState)
+import Data.Maybe (Maybe(..))
 import Data.Traversable (for, for_)
 import Data.Tuple (snd)
+import Data.Tuple.Nested ((/\))
 import Unsafe.Coerce (unsafeCoerce)
 
 type Name = String
@@ -77,12 +80,10 @@ class Example eff arg fun
   , fun -> arg
   , fun -> eff
   where
-  eval :: fun -> AVar arg -> Aff eff Unit
+  eval :: fun -> arg -> Aff eff Unit
 
 instance exampleFunc :: Example eff arg (arg -> Aff eff Unit) where
-  eval f var = do
-    arg <- unsafeCoerceAff $ peekVar var -- TODO: make this safe
-    f arg
+  eval f arg = f arg
 
 instance exampleAff :: Example eff a (Aff eff Unit) where
   eval u _ = u
@@ -93,7 +94,7 @@ type SpecEffects e =  ( console :: CONSOLE
                       , avar    :: AVAR
                       | e)
 type Spec eff r = SpecWith (Aff eff Unit) r
-type SpecWith a r = State (Array (Group a)) r
+type SpecWith a r = State (Array (Group (AVar Unit -> a))) r
 
 collect
   :: ∀ t r
@@ -149,7 +150,7 @@ pending
    . Example eff arg fun
   => String
   -> SpecWith fun Unit
-pending name = modify $ \p -> p <> [Pending name]
+pending name = modify (_ <> [Pending name])
 
 -- | Create a pending spec with a body that is ignored by
 -- | the runner. It can be useful for documenting what the
@@ -169,7 +170,7 @@ it
   => String
   -> fun
   -> SpecWith fun Unit
-it description example = modify (_ <> [It false description example])
+it description example = modify (_ <> [It false description \_ -> example])
 
 -- | Create a spec with a description and mark it as the only one to
 -- | be run. (useful for quickly narrowing down on a single test)
@@ -179,20 +180,70 @@ itOnly
   => String
   -> fun
   -> SpecWith fun Unit
-itOnly description example = modify (_ <> [It true description example])
+itOnly description example = modify (_ <> [It true description \_ -> example])
+
+-- | Run an effectful computation around each test, passing the result to
+-- | the test and cleaning up afterwards
+_around
+  :: ∀ eff1 eff2 eff3 eff4 fun1 arg1
+   . Example eff3 arg1 fun1
+  => Boolean -- cached?
+  -> Aff eff1 arg1
+  -> (arg1 -> Aff eff2 Unit)
+  -> SpecWith fun1 Unit
+  -> Spec eff4 Unit
+_around cache before after spec = modify $ const $
+  let groups = collect spec
+   in groups <#> \group ->
+        group <#> \example ->
+          \ctx -> do
+            -- TODO: this is not composable but a necessary evil
+            v /\ ctx' <- unsafeCoerceAff do
+              tryPeekVar ctx >>= case _ of
+                Just v -> pure (unsafeCoerce v)
+                Nothing -> do
+                  ctx' <- makeVar
+                  v <- unsafeCoerceAff $ before
+                  putVar ctx (unsafeCoerce $ v /\ ctx')
+                  pure $ v /\ ctx'
+            unsafeCoerceAff $ eval (example ctx') v
+            unsafeCoerceAff $ after v
 
 -- | Run an effectful computation around each test, passing the result to
 -- | the test and cleaning up afterwards
 aroundEach
-  :: ∀ eff1 eff2 eff3 eff4 fun1 fun2 arg1
+  :: ∀ eff1 eff2 eff3 eff4 fun1 arg1
    . Example eff3 arg1 fun1
-  => Example eff4 Unit fun2
   => Aff eff1 arg1
   -> (arg1 -> Aff eff2 Unit)
   -> SpecWith fun1 Unit
-  -> SpecWith fun2 Unit
-aroundEach before after spec = modify $ const $
-  let groups = collect spec
-   in groups <#> \group ->
-        group <#> \example -> do
-          unsafeCoerceAff $ Console.log "..." --
+  -> Spec eff4 Unit
+aroundEach = _around false
+
+-- | Run an effectful computation around before each test
+beforeEach
+  :: ∀ eff1 eff2 eff3 eff4 fun1 arg1
+   . Example eff3 arg1 fun1
+  => Aff eff1 arg1
+  -> SpecWith fun1 Unit
+  -> Spec eff4 Unit
+beforeEach = flip (_around false) (const $ pure unit)
+
+-- | Run an effectful computation around before each test
+afterEach
+  :: ∀ eff1 eff2 eff3 eff4 fun1
+   . Example eff3 Unit fun1
+  => (Unit -> Aff eff2 Unit)
+  -> SpecWith fun1 Unit
+  -> Spec eff4 Unit
+afterEach = _around false (pure unit)
+
+-- | Run an effectful computation around all tests, passing the result to
+-- | the test without evaluating it twice
+beforeAll
+  :: ∀ eff1 eff2 eff3 eff4 fun1 arg1
+   . Example eff3 arg1 fun1
+  => Aff eff1 arg1
+  -> SpecWith fun1 Unit
+  -> Spec eff4 Unit
+beforeAll before spec = _around true before (const $ pure unit) spec

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -35,7 +35,7 @@ import Pipes ((>->), yield)
 import Pipes (for) as P
 import Pipes.Core (Pipe, Producer, (//>))
 import Pipes.Core (runEffectRec) as P
-import Test.Spec (Spec, Group(..), Result(..), SpecEffects, collect)
+import Test.Spec (Spec, Group(..), Result(..), SpecEffects, collect, eval)
 import Test.Spec.Console (withAttrs)
 import Test.Spec.Runner.Event (Event)
 import Test.Spec.Speed (speedOf)
@@ -118,8 +118,8 @@ _run config spec = do
     yield Event.Test
     start    <- lift $ liftEff dateNow
     e        <- lift $ attempt case config.timeout of
-                                      Just t -> timeout t $ test unit
-                                      _      -> test unit
+                                      Just t -> timeout t $ eval test
+                                      _      -> eval test
     duration <- lift $ (_ - start) <$> liftEff dateNow
     yield $ either
       (\err ->

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -118,8 +118,8 @@ _run config spec = do
     yield Event.Test
     start    <- lift $ liftEff dateNow
     e        <- lift $ attempt case config.timeout of
-                                      Just t -> timeout t $ eval test
-                                      _      -> eval test
+                                      Just t -> timeout t $ eval test unit
+                                      _      -> eval test unit
     duration <- lift $ (_ - start) <$> liftEff dateNow
     yield $ either
       (\err ->

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -118,8 +118,8 @@ _run config spec = do
     yield Event.Test
     start    <- lift $ liftEff dateNow
     e        <- lift $ attempt case config.timeout of
-                                      Just t -> timeout t test
-                                      _      -> test
+                                      Just t -> timeout t $ test unit
+                                      _      -> test unit
     duration <- lift $ (_ - start) <$> liftEff dateNow
     yield $ either
       (\err ->

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,11 +3,11 @@ module Test.Main where
 import Prelude
 import Control.Monad.Eff (Eff)
 import Test.Spec.AssertionSpec (assertionSpec)
-import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Reporter (specReporter)
 import Test.Spec.Runner (RunnerEffects, run)
 import Test.Spec.RunnerSpec (runnerSpec)
 
 main :: Eff (RunnerEffects ()) Unit
-main = run [ consoleReporter ] do
+main = run [ specReporter ] do
   runnerSpec
   assertionSpec

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -5,7 +5,7 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff (delay)
 import Control.Monad.Aff.Console as Console
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, afterEach, aroundEach)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, aroundEach)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -38,8 +38,7 @@ runnerSpec =
 
       describe "aroundEach" do
         aroundEach
-          (pure 10)
-          (_ `shouldEqual` 10) do
-            it "should pass result to \"it\" (1)" \s -> do
-              s `shouldEqual` 10
-
+          ((pure 10) :: Aff _ Int)
+          ((Console.log <<< show) :: Int -> Aff _ Unit) do
+            it "should pass result to \"it\" (1)" do
+              10 `shouldEqual` 10

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -3,7 +3,7 @@ module Test.Spec.RunnerSpec where
 import Prelude
 import Control.Monad.Aff (delay)
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, it1)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -37,8 +37,8 @@ runnerSpec =
 
       describe "beforeEach" do
         beforeEach (pure "bar") do
-          it1 "should pass result to \"it\" (1)" \s ->
+          it "should pass result to \"it\" (1)" \s ->
             s `shouldEqual` "bar"
 
-          it1 "should pass result to \"it\" (2)" \s ->
+          it "should pass result to \"it\" (2)" \s ->
             s `shouldEqual` "bar"

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -1,15 +1,16 @@
 module Test.Spec.RunnerSpec where
 
 import Prelude
+import Control.Monad.Aff (Aff)
 import Control.Monad.Aff (delay)
+import Control.Monad.Aff.Console as Console
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
-import Control.Monad.Aff.Console as Console
 
-runnerSpec :: ∀ e. Spec (RunnerEffects e) Unit
+runnerSpec :: ∀ e eff. Spec (RunnerEffects e) Unit
 runnerSpec =
   describe "Test" $
     describe "Spec" do
@@ -34,3 +35,8 @@ runnerSpec =
         it "supports async" do
           res <- delay (Milliseconds 10.0) *> pure 1
           res `shouldEqual` 1
+
+      describe "beforeEach" do
+        beforeEach (pure 10) do
+          it "should pass result to \"it\" (1)" \s -> do
+            s `shouldEqual` 10

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -5,7 +5,7 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff (delay)
 import Control.Monad.Aff.Console as Console
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, afterEach)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -37,6 +37,8 @@ runnerSpec =
           res `shouldEqual` 1
 
       describe "beforeEach" do
-        beforeEach (pure 10) do
-          it "should pass result to \"it\" (1)" \s -> do
-            s `shouldEqual` 10
+        afterEach (Console.log "done") do
+          beforeEach (pure 10) do
+            it "should pass result to \"it\" (1)" \s -> do
+              s `shouldEqual` 10
+

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -3,15 +3,16 @@ module Test.Spec.RunnerSpec where
 import Prelude
 import Control.Monad.Aff (delay)
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, it1)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
+import Control.Monad.Aff.Console as Console
 
 runnerSpec :: ∀ e. Spec (RunnerEffects e) Unit
 runnerSpec =
   describe "Test" $
-    describe "Spec" $
+    describe "Spec" do
       describe "Runner" do
         it "collects \"it\" and \"pending\" in Describe groups" do
           results <- runSpec successTest
@@ -33,3 +34,11 @@ runnerSpec =
         it "supports async" do
           res <- delay (Milliseconds 10.0) *> pure 1
           res `shouldEqual` 1
+
+      describe "beforeEach" do
+        beforeEach (pure "bar") do
+          it1 "should pass result to \"it\" (1)" \s ->
+            s `shouldEqual` "bar"
+
+          it1 "should pass result to \"it\" (2)" \s ->
+            s `shouldEqual` "bar"

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -5,7 +5,7 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff (delay)
 import Control.Monad.Aff.Console as Console
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, aroundEach)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, aroundEach, beforeAll)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -37,8 +37,15 @@ runnerSpec =
           res `shouldEqual` 1
 
       describe "aroundEach" do
-        aroundEach
-          ((pure 10) :: Aff _ Int)
-          ((Console.log <<< show) :: Int -> Aff _ Unit) do
+        beforeAll
+          (Console.log "LETS GO") do
             it "should pass result to \"it\" (1)" do
               10 `shouldEqual` 10
+            it "should pass result to \"it\" (1)" do
+              10 `shouldEqual` 10
+            beforeAll
+              (Console.log "LETS GO 2") do
+                it "should pass result to \"it\" (1)" do
+                  10 `shouldEqual` 10
+                it "should pass result to \"it\" (1)" do
+                  10 `shouldEqual` 10

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -3,7 +3,7 @@ module Test.Spec.RunnerSpec where
 import Prelude
 import Control.Monad.Aff (delay)
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach)
+import Test.Spec (Group(..), Result(..), Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -34,11 +34,3 @@ runnerSpec =
         it "supports async" do
           res <- delay (Milliseconds 10.0) *> pure 1
           res `shouldEqual` 1
-
-      describe "beforeEach" do
-        beforeEach (pure "bar") do
-          it "should pass result to \"it\" (1)" \s ->
-            s `shouldEqual` "bar"
-
-          it "should pass result to \"it\" (2)" \s ->
-            s `shouldEqual` "bar"

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -5,7 +5,7 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff (delay)
 import Control.Monad.Aff.Console as Console
 import Data.Time.Duration (Milliseconds(..))
-import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, afterEach)
+import Test.Spec (Group(..), Result(..), Spec, describe, it, beforeEach, afterEach, aroundEach)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Runner (RunnerEffects, runSpec)
@@ -36,9 +36,10 @@ runnerSpec =
           res <- delay (Milliseconds 10.0) *> pure 1
           res `shouldEqual` 1
 
-      describe "beforeEach" do
-        afterEach (Console.log "done") do
-          beforeEach (pure 10) do
+      describe "aroundEach" do
+        aroundEach
+          (pure 10)
+          (_ `shouldEqual` 10) do
             it "should pass result to \"it\" (1)" \s -> do
               s `shouldEqual` 10
 


### PR DESCRIPTION
PR for #44 

Implement "hooks" that allow running before all, before each, after all and after each test.

#### TODO:

* [x] beforeEach
* [x] beforeAll
* [ ] afterAll
* [x] afterEach
* [ ] aroundAll
* [x] aroundEach

#### Caveats:

* The approach taken is not as composable as I would like it to be. For example, nested `beforeEach` actions do not compose. The way it is currently implemented, a `beforeEach` essentially decorates a single `it` block but does not share the same type with `it`. There _may_ be a way around this one, but I have not had a chance yet to fully explore this.
* The implementation for `beforeAll` (and later `afterAll`) is kludgy at best and requires a call to `unsafeCoerce`. It also tightly couples the runner logic with the actual spec. The only way that I see to get around this is to either extend / generalize the group ADT or build the entire Spec in Aff. I would prefer the former, but that's a larger undertaking than what I have time for at this point.

At this point, I am not sure if we should even look at merging this. The cool thing is that the DSL and external facing types have not changed and likely won't have to change if we were to re-iterate in an effort to make it more composable.