### PR TITLE
Renamed PROCESS effect to SPEC_PROCESS to avoid conflicts with Node.P…

### DIFF
--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -9,7 +9,7 @@ module Test.Spec.Runner
        , Config
        , TestEvents
        , Reporter
-       , PROCESS
+       , SPEC_PROCESS
        ) where
 
 import Prelude
@@ -43,11 +43,11 @@ import Test.Spec.Runner.Event as Event
 import Test.Spec.Speed (speedOf)
 import Test.Spec.Summary (successful)
 
-foreign import data PROCESS :: Effect
+foreign import data SPEC_PROCESS :: Effect
 
-foreign import exit :: forall eff. Int -> Eff (process :: PROCESS | eff) Unit
+foreign import exit :: forall eff. Int -> Eff (specProcess :: SPEC_PROCESS | eff) Unit
 
-type RunnerEffects e = SpecEffects (process :: PROCESS | e)
+type RunnerEffects e = SpecEffects (specProcess :: SPEC_PROCESS | e)
 
 foreign import dateNow :: ∀ e. Eff e Int
 


### PR DESCRIPTION
…rocess.PROCESS

The effect conflicts with Node.Process.PROCESS, so nothing effectful from purescript-node-process that uses the PROCESS effect (ie `cwd`) can be used with purescript-spec. This fixes that problem by renaming the effect to SPEC_PROCESS.