### PR TITLE
Add a new exit flag to Test.Spec.Runner.Config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .psci
 .psci_modules/
 bower_components/
+generated-docs/
 node_modules/
 output/
 tmp/

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@ main = run [consoleReporter] do
 <p>In addition to the regular <code>run</code> function, there is also <code>run'</code>, which takes a <code>Config</code> record.</p>
 <pre class="purescript"><code>main = run&#39; testConfig [consoleReporter] mySpec
   where
-    testConfig = { slow: 5000, timeout: Just 10000 }</code></pre>
+    testConfig = { slow: 5000, timeout: Just 10000, exit: false }</code></pre>
 <p>The <code>Test.Spec.Runner</code> module provides a <code>defaultConfig</code> value which you can use to override only specific values.</p>
 <pre class="purescript"><code>main = run&#39; testConfig [consoleReporter] mySpec
   where

--- a/docs/running.md
+++ b/docs/running.md
@@ -48,7 +48,7 @@ In addition to the regular `run` function, there is also `run'`, which takes a
 ```purescript
 main = run' testConfig [consoleReporter] mySpec
   where
-    testConfig = { slow: 5000, timeout: Just 10000 }
+    testConfig = { slow: 5000, timeout: Just 10000, exit: false }
 ```
 
 The `Test.Spec.Runner` module provides a `defaultConfig` value which you


### PR DESCRIPTION
This means the run' function does not always have to exit the process.

This is to help fix https://github.com/purescript-spec/purescript-spec-reporter-xunit/issues/3