### PR TITLE
Flip exit codes to the correct ones

### DIFF
--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -167,7 +167,7 @@ run' config reporters spec = void do
 
     onSuccess :: Array (Group Result) -> Effect Unit
     onSuccess results = when config.exit do
-                          let code = if successful results then 1 else 0
+                          let code = if successful results then 0 else 1
                           exit code
 
 run


### PR DESCRIPTION
https://github.com/purescript-spec/purescript-spec/commit/da88e3cd14df721c93b7f48b65ce896e89e1df5e#diff-6284d4c18f32617e31426063da6476aeR170 introduced a bug: it makes the test suite exit with a success exit code on failure, and with a failure exit code on success.