### PR TITLE
Redefine `run` and `run'` to return `Aff Unit`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -87,14 +87,14 @@ import Prelude
 
 import Data.Time.Duration (Milliseconds(..))
 import Effect (Effect)
-import Effect.Aff (delay)
+import Effect.Aff (launchAff_, delay)
 import Test.Spec (pending, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (run)
 
 main :: Effect Unit
-main = run [consoleReporter] do
+main = launchAff_ $ run [consoleReporter] do
   describe &quot;purescript-spec&quot; do
     describe &quot;Attributes&quot; do
       it &quot;awesome&quot; do
@@ -149,11 +149,11 @@ main = run [consoleReporter] do
 </ul>
 <h3 id="passing-runner-configuration">Passing Runner Configuration</h3>
 <p>In addition to the regular <code>run</code> function, there is also <code>run'</code>, which takes a <code>Config</code> record.</p>
-<pre class="purescript"><code>main = run&#39; testConfig [consoleReporter] mySpec
+<pre class="purescript"><code>main = launchAff_ $ run&#39; testConfig [consoleReporter] mySpec
   where
     testConfig = { slow: 5000, timeout: Just 10000, exit: false }</code></pre>
 <p>The <code>Test.Spec.Runner</code> module provides a <code>defaultConfig</code> value which you can use to override only specific values.</p>
-<pre class="purescript"><code>main = run&#39; testConfig [consoleReporter] mySpec
+<pre class="purescript"><code>main = launchAff_ $ run&#39; testConfig [consoleReporter] mySpec
   where
     testConfig = defaultConfig { slow = 100 }</code></pre>
 <h3 id="automatically-discovering-specs">Automatically Discovering Specs</h3>

--- a/docs/running.md
+++ b/docs/running.md
@@ -46,7 +46,7 @@ In addition to the regular `run` function, there is also `run'`, which takes a
 `Config` record.
 
 ```purescript
-main = run' testConfig [consoleReporter] mySpec
+main = launchAff_ $ run' testConfig [consoleReporter] mySpec
   where
     testConfig = { slow: 5000, timeout: Just 10000, exit: false }
 ```
@@ -55,7 +55,7 @@ The `Test.Spec.Runner` module provides a `defaultConfig` value which you
 can use to override only specific values.
 
 ```purescript
-main = run' testConfig [consoleReporter] mySpec
+main = launchAff_ $ run' testConfig [consoleReporter] mySpec
   where
     testConfig = defaultConfig { slow = 100 }
 ```

--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -83,14 +83,14 @@ import Prelude
 
 import Data.Time.Duration (Milliseconds(..))
 import Effect (Effect)
-import Effect.Aff (delay)
+import Effect.Aff (launchAff_, delay)
 import Test.Spec (pending, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (run)
 
 main :: Effect Unit
-main = run [consoleReporter] do
+main = launchAff_ $ run [consoleReporter] do
   describe "purescript-spec" do
     describe "Attributes" do
       it "awesome" do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,12 +2,13 @@ module Test.Main where
 
 import Prelude
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.Spec.AssertionSpec (assertionSpec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (run)
 import Test.Spec.RunnerSpec (runnerSpec)
 
 main :: Effect Unit
-main = run [ consoleReporter ] do
+main = launchAff_ $ run [ consoleReporter ] do
   runnerSpec
   assertionSpec


### PR DESCRIPTION
Since `run :: Effect Unit` would return immediately and then run on the side - it would be better if our entrypoint was to return `Aff Unit` which can then be awaited.

The drawback is that users will now have broken code and have to include `launchAff_` when running their main:

```haskell
main :: Effect Unit
main = launchAff_ $ run [ consoleReporter ] do ...
```

This fixes @Dretch's issue with xunit.

Thoughts, @owickstrom ?