### PR TITLE
Update Pandoc options; resolves #95.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ docs/index.html: $(MD_SOURCES) docs/template.html docs/docs.css
 	pandoc $(SHARED_PANDOC_OPTIONS) \
 		-t html5 \
 		--standalone \
-		-S \
 		--toc \
-		--chapters \
+		--top-level-division=chapter \
 		"--metadata=subtitle:$(VERSION)" \
 		--no-highlight \
 		-c docs.css \


### PR DESCRIPTION
As I mentioned in #95, Pandoc options have changed since the Makefile was written. The CLI was clear about updating ```--chapters``` to ```--top-level-division=chapter```; but it was less clear what to do with the ```-S``` option. However, the [Pandoc User's Guide](https://pandoc.org/MANUAL.html) doesn't list ```html5``` (or ```html```) in the list of formats that support the ```smart``` extension that was previously enabled with ```-S```.