### PR TITLE
Docs: Fix test configuration example types

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -49,7 +49,7 @@ then code will look like this:
 ```purescript
 main = launchAff_ $ un Identity $ runSpecT testConfig [consoleReporter] mySpec
   where
-    testConfig = { slow: 5000, timeout: Just 10000, exit: false }
+    testConfig = { slow: Milliseconds 5000.0, timeout: Just $ Milliseconds 10000.0, exit: false }
 ```
 
 ## Automatically Discovering Specs


### PR DESCRIPTION
Types for timeout and slow were not correct

https://github.com/purescript-spec/purescript-spec/blob/a91d77654c4a6ac314b42bae941892dd576c4916/src/Test/Spec/Runner.purs#L52-L64