### PR TITLE
unsafePartial ∘ fromRight ∘ regex → unsafeRegex

### DIFF
--- a/src/Test/Spec/Reporter/Tap.purs
+++ b/src/Test/Spec/Reporter/Tap.purs
@@ -3,13 +3,12 @@ module Test.Spec.Reporter.Tap (tapReporter) where
 import Prelude
 
 import Control.Monad.State (get, modify_)
-import Data.Either (fromRight)
 import Data.Maybe (Maybe(..))
 import Data.String (Pattern(Pattern), joinWith, split)
 import Data.String.Regex (regex)
 import Data.String.Regex as Regex
+import Data.String.Regex.Unsafe (unsafeRegex)
 import Effect.Exception as Error
-import Partial.Unsafe (unsafePartial)
 import Test.Spec.Console (tellLn)
 import Test.Spec.Reporter.Base (defaultReporter)
 import Test.Spec.Result (Result(..))
@@ -49,12 +48,12 @@ tapReporter = defaultReporter 1 case _ of
 
 -- create a TAP-safe title
 escMsg :: String -> String
-escMsg =
-  let rex = unsafePartial $ fromRight $ regex "^" $ Regex.parseFlags "gm"
-    in Regex.replace rex "  "
+escMsg = Regex.replace rex "  "
+  where
+  rex = unsafeRegex "^" $ Regex.parseFlags "gm"
 
 -- create a TAP-safe error msg
 escTitle :: String -> String
-escTitle =
-  let rex = unsafePartial $ fromRight $ regex "#" $ Regex.parseFlags "g"
-    in Regex.replace rex ""
+escTitle = Regex.replace rex ""
+  where
+  rex = unsafeRegex "#" $ Regex.parseFlags "g"

--- a/src/Test/Spec/Reporter/Tap.purs
+++ b/src/Test/Spec/Reporter/Tap.purs
@@ -5,7 +5,6 @@ import Prelude
 import Control.Monad.State (get, modify_)
 import Data.Maybe (Maybe(..))
 import Data.String (Pattern(Pattern), joinWith, split)
-import Data.String.Regex (regex)
 import Data.String.Regex as Regex
 import Data.String.Regex.Unsafe (unsafeRegex)
 import Effect.Exception as Error


### PR DESCRIPTION
Since this function exists in the `purescript-strings` library, there's no need to reinvent this functionality. In the future `Data.Either.fromRight` won't be partial either (see [either #56](https://github.com/purescript/purescript-either/issues/56) and [string #128](https://github.com/purescript/purescript-strings/pull/128)) and this will fail to compile. This PR may also remove the dependencies on Either and Partial as well if they weren't used elsewhere.