### PR TITLE
Fix Travis script for PS 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,12 @@ node_js: 10
 env:
   - PATH=$HOME/purescript:$PATH
 install:
-  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/v0.12.0/linux64.tar.gz
-  - tar -xvf $HOME/purescript.tar.gz -C $HOME/
-  - chmod a+x $HOME/purescript
-  - npm install -g bower pulp
-  - bower install
+  - npm install -g bower pulp purescript@0.14.0
+  - npx bower install
 script:
-  - travis_wait pulp build
+  - travis_wait npx pulp build
   - travis_wait make run-example
-  - travis_wait pulp test
+  - travis_wait npx pulp test
 
 cache:
   directories:


### PR DESCRIPTION
Turns out the Travis script was specifically installing PS 0.12.0, so the build failed after updating dependencies.

I wonder why it didn't fail on the pull request though?..