### PR TITLE
Remove unused names

### DIFF
--- a/src/Test/Spec/Reporter/Base.purs
+++ b/src/Test/Spec/Reporter/Base.purs
@@ -66,7 +66,7 @@ printFailures xs' = evalStateT (go xs') {i: 0, crumbs: Nil}
         State.modify_ _{crumbs = n : crumbs}
         go xs
         State.modify_ _{crumbs = crumbs}
-      S.Node (Right v) xs -> absurd v
+      S.Node (Right v) _ -> absurd v
       S.Leaf n (Just (Failure err)) -> do
         {i, crumbs} <- State.modify \s -> s{i = s.i +1}
         let label = intercalate " " (reverse $ n:crumbs)
@@ -130,12 +130,12 @@ defaultUpdate opts e = do
       Event.SuiteEnd path -> do
         modifyRunningItems $ flip Map.update path case _ of
           RunningSuite n _ -> Just $ RunningSuite n true
-          a -> Nothing
-      Event.Test Event.Sequential path name -> do
+          _ -> Nothing
+      Event.Test Event.Sequential _ _ -> do
         pure unit
       Event.Test Event.Parallel path name -> do
         modifyRunningItems $ Map.insert path $ RunningTest name Nothing
-      Event.TestEnd path name res -> do
+      Event.TestEnd path _ res -> do
         runningItem <- gets opts.getRunningItems
         case Map.lookup path runningItem of
           Just (RunningTest n _) ->

--- a/src/Test/Spec/Reporter/Console.purs
+++ b/src/Test/Spec/Reporter/Console.purs
@@ -97,7 +97,7 @@ print path a = do
           $ intercalate " » " (parentSuiteName suite.path <> [suite.name])
         put s{lastPrintedSuitePath = Just suite.path}
   case a of
-    PrintTest name (Success speed ms) -> do
+    PrintTest name (Success _ _) -> do
       tellLn $ "  " <> styled Style.green "✓︎ " <> styled Style.dim name
     PrintTest name (Failure err) -> do
       tellLn $ "  " <> styled Style.red ("✗ " <> name <> ":")

--- a/src/Test/Spec/Reporter/Spec.purs
+++ b/src/Test/Spec/Reporter/Spec.purs
@@ -76,7 +76,7 @@ print path = case _ of
         Speed.Fast -> ""
         _ -> styled (Speed.toStyle speed) $ " (" <> show (Int.round ms) <> "ms)"
     tellLn $ (indent path) <> styled Style.green "✓︎ " <> styled Style.dim name <> speedDetails
-  PrintTest name (Failure err) -> do
+  PrintTest name (Failure _) -> do
     {numFailures} <- modify \s -> s{numFailures = s.numFailures +1}
     tellLn $ (indent path) <> styled Style.red (show numFailures <> ") " <> name)
   PrintPending name -> do

--- a/src/Test/Spec/Result.purs
+++ b/src/Test/Spec/Result.purs
@@ -8,7 +8,6 @@ import Effect.Exception (Error)
 import Effect.Exception as Error
 import Test.Spec.Speed (Speed)
 
-
 data Result
   = Success Speed Milliseconds
   | Failure Error

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -152,7 +152,7 @@ mergeProducers ps = do
     loop = do
       res <- lift $ try (AV.take var)
       case res of
-        Left err -> lift $ joinFiber fib
+        Left _ -> lift $ joinFiber fib
         Right e -> do
           yield e
           loop


### PR DESCRIPTION
Removes unused names, which now warn as of PureScript 0.14.1.