### PR TITLE
Parenthesis missing?

### DIFF
--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -18,7 +18,7 @@ works!
 
 ```purescript
 it "adds 1 and 1" do
-  1 + 1 `shouldEqual` 2
+  (1 + 1) `shouldEqual` 2
 ```
 
 The `shouldEqual` function, here used as an infix operator, takes two values


### PR DESCRIPTION
I believe the PureScript binding rules makes for () surrounding 1 + 1. At least that is what made my test code compile after scratching head from this error message:

```at test/Main.purs:16:9 - 16:26 (line 16, column 9 - line 16, column 26)

  Could not match type
           
    t0 Unit
           
  with type
       
    Int
       

while checking that type t0 Unit
  is at least as general as type Int
while checking that expression (shouldEqual 1) 2
  has type Int
in value declaration main

where t0 is an unknown type
```