### PR TITLE
Add `shouldEqualAny` to assert without `Show`

### DIFF
--- a/src/Test/Spec/Assertions.js
+++ b/src/Test/Spec/Assertions.js
@@ -1,0 +1,1 @@
+export const unsafeStringify = x => JSON.stringify(x, null, 2)

--- a/src/Test/Spec/Assertions.purs
+++ b/src/Test/Spec/Assertions.purs
@@ -1,6 +1,7 @@
 module Test.Spec.Assertions
   ( fail
   , shouldEqual
+  , shouldEqualAny
   , shouldNotEqual
   , shouldContain
   , shouldNotContain
@@ -32,6 +33,18 @@ shouldEqual
 shouldEqual v1 v2 =
   when (v1 /= v2) $
     fail $ show v1 <> " ≠ " <> show v2
+
+foreign import unsafeStringify :: forall a. a -> String
+shouldEqualAny
+  :: forall m t
+   . MonadThrow Error m
+  => Eq t
+  => t
+  -> t
+  -> m Unit
+shouldEqualAny v1 v2 =
+  when (v1 /= v2) $
+    fail $ unsafeStringify v1 <> " ≠ " <>  unsafeStringify v2
 
 shouldNotEqual
   :: forall m t

--- a/test/Test/Spec/AssertionSpec.purs
+++ b/test/Test/Spec/AssertionSpec.purs
@@ -1,11 +1,15 @@
 module Test.Spec.AssertionSpec where
 
 import Prelude
-import Effect.Exception (error)
+
 import Control.Monad.Error.Class (throwError)
+import Effect.Exception (error)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions as A
 import Test.Spec.Assertions.String as AS
+
+newtype MyInt = MyInt Int
+derive newtype instance Eq MyInt
 
 assertionSpec :: Spec Unit
 assertionSpec =
@@ -19,6 +23,10 @@ assertionSpec =
               "foobar" `AS.shouldContain` "foo"
             it "rejects strings that does not contain substrings" $
               A.expectError $ "baz" `AS.shouldContain` "foo"
+
+          describe "shouldEqualAny" do
+            it "any type with an Eq instance" $
+              MyInt 3 `A.shouldEqualAny` MyInt 3
 
           describe "shouldNotContain" do
             it "accepts strings that does not contain substrings" $


### PR DESCRIPTION
`shouldEqual` requires both values to have a
`Show` instance which might not be easy to
obtain if the type is not under the user's
control.