### PR TITLE
Add purescript-console back as a pupl/bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
         "purescript-arrays": "^v7.1.0",
         "purescript-avar": "^v5.0.0",
         "purescript-bifunctors": "^v6.0.0",
+        "purescript-console": "^v6.0.0",
         "purescript-control": "^v6.0.0",
         "purescript-datetime": "^v6.1.0",
         "purescript-effect": "^v4.0.0",


### PR DESCRIPTION
It is used during the command `pulp test` and will fail the ci if not part of the dependencies