### PR TITLE
Support parallell teamcity

### DIFF
--- a/src/Test/Spec/Reporter/TeamCity.purs
+++ b/src/Test/Spec/Reporter/TeamCity.purs
@@ -8,7 +8,9 @@ import Data.Array ((:))
 import Data.Array (intercalate) as Array
 import Data.Int (trunc)
 import Data.Map.Internal as Map
+import Data.Maybe (Maybe, fromMaybe)
 import Data.Maybe (fromMaybe) as Maybe
+import Data.Newtype (unwrap)
 import Data.String.Regex (replace') as Regex
 import Data.String.Regex.Flags (global) as Regex
 import Data.String.Regex.Unsafe (unsafeRegex) as Regex
@@ -20,6 +22,7 @@ import Test.Spec.Reporter.Base (defaultReporter)
 import Test.Spec.Result (Result(..))
 import Test.Spec.Runner (Reporter)
 import Test.Spec.Runner.Event (Event(..)) as Event
+import Test.Spec.Tree (Path, parentSuite)
 
 escape :: String -> String
 escape = Regex.replace'
@@ -39,51 +42,92 @@ teamcity name properties = "##teamcity[" <> body <> "]"
   body = name : (properties <#> renderProperty) # Array.intercalate " "
   renderProperty (key /\ value) = key <> "='" <> escape value <> "'"
 
+message :: forall a. String -> ServiceMessage a -> String
+message event { name, nodeId, parentNodeId } = teamcity event
+  [ "name" /\ name
+  , "nodeId" /\ nodeId
+  , "parentNodeId" /\ (fromMaybe "0" parentNodeId)
+  ]
+
 testCount :: Int -> String
 testCount count = teamcity "testCount" [ "count" /\ show count ]
 
-testSuiteStarted :: Array (Tuple String String) -> String
-testSuiteStarted = teamcity "testSuiteStarted"
+testSuiteStarted :: ServiceMessage () -> String
+testSuiteStarted = message "testSuiteStarted"
 
-testSuiteFinished :: Array (Tuple String String) -> String
-testSuiteFinished = teamcity "testSuiteFinished"
+testSuiteFinished :: ServiceMessage () -> String
+testSuiteFinished = message "testSuiteFinished"
 
-testStarted :: Array (Tuple String String) -> String
-testStarted = teamcity "testStarted"
+testFinishedIn :: WithDuration -> String
+testFinishedIn { name, nodeId, parentNodeId, duration } =
+  teamcity "testFinished"
+    [ "name" /\ name
+    , "nodeId" /\ nodeId
+    , "duration" /\ show (trunc duration)
+    , "parentNodeId" /\ (fromMaybe "0" parentNodeId)
+    ]
 
-testIgnored :: Array (Tuple String String) -> String
-testIgnored = teamcity "testIgnored"
+testFailed :: WithMessage -> String
+testFailed { name, nodeId, parentNodeId, message } =
+  teamcity "testFailed"
+    [ "name" /\ name
+    , "nodeId" /\ nodeId
+    , "message" /\ message
+    , "parentNodeId" /\ (fromMaybe "0" parentNodeId)
+    ]
 
-testFinished :: Array (Tuple String String) -> String
-testFinished = teamcity "testFinished"
+type ServiceMessage x =
+  { name :: String
+  , nodeId :: String
+  , parentNodeId :: Maybe String
+  | x
+  }
 
-testFailed :: Array (Tuple String String) -> String
-testFailed = teamcity "testFailed"
+serviceMessage :: String -> Path -> ServiceMessage ()
+serviceMessage name' path =
+  let
+    name = name'
+    nodeId = idFromPath path
+    parentNodeId = parentSuite path
+      <#> _.path
+      <#> idFromPath
+  in
+    { name, nodeId, parentNodeId }
+
+type WithMessage = ServiceMessage (message :: String)
+type WithDuration = ServiceMessage (duration :: Number)
+
+idFromPath :: Path -> String
+idFromPath path = path
+  <#> unwrap
+  <#> (\{ index, name } -> show index <> ":" <> fromMaybe "" name)
+  # Array.intercalate ","
 
 teamcityReporter :: Reporter
 teamcityReporter = defaultReporter Map.empty case _ of
   Event.Suite _ path name -> do
     void $ modify $ Map.insert path name
-    tellLn $ testSuiteStarted [ "name" /\ name ]
+    tellLn $ testSuiteStarted $ serviceMessage name path
   Event.SuiteEnd path -> do
     name <- get <#> Map.lookup path <#> Maybe.fromMaybe ""
-    tellLn $ testSuiteFinished [ "name" /\ name ]
-  Event.Test _ _ name ->
-    tellLn $ testStarted [ "name" /\ name ]
-  Event.Pending _ name -> do
-    tellLn $ testStarted [ "name" /\ name ]
-    tellLn $ testIgnored [ "name" /\ name ]
-    tellLn $ testFinished [ "name" /\ name ]
-  Event.TestEnd _ name (Success _ (Milliseconds millies)) -> do
-    tellLn $ testFinished
-      [ "name" /\ name
-      , "duration" /\ show (trunc millies)
-      ]
-  Event.TestEnd _ name (Failure error) -> do
-    tellLn $ testFailed
-      [ "name" /\ name
-      , "message" /\ show error
-      ]
-    tellLn $ testFinished [ "name" /\ name ]
+    tellLn $ testSuiteFinished $ serviceMessage name path
+  Event.Test _ path name -> do
+    tellLn $ message "testStarted" $ serviceMessage name path
+  Event.Pending path name -> do
+    let attributes = serviceMessage name path
+    tellLn $ message "testStarted" attributes
+    tellLn $ message "testIgnored" attributes
+    tellLn $ message "testFinished" attributes
+  Event.TestEnd path name' (Success _ (Milliseconds millies)) -> do
+    let
+      { name, nodeId, parentNodeId } = serviceMessage name' path
+      attributes = { name, nodeId, parentNodeId, duration: millies }
+    tellLn $ testFinishedIn attributes
+  Event.TestEnd path name' (Failure error) -> do
+    let
+      { name, nodeId, parentNodeId } = serviceMessage name' path
+      attributes = { name, nodeId, parentNodeId, message: show error }
+    tellLn $ testFailed attributes
+    tellLn $ message "testFinished" attributes
   Event.End _ -> pure unit
   Event.Start count -> tellLn $ testCount count

--- a/src/Test/Spec/Reporter/TeamCity.purs
+++ b/src/Test/Spec/Reporter/TeamCity.purs
@@ -92,6 +92,9 @@ type ServiceMessage x =
   | x
   }
 
+type WithMessage = ServiceMessage (message :: String)
+type WithDuration = ServiceMessage (duration :: Number)
+
 serviceMessage :: String -> Path -> ServiceMessage ()
 serviceMessage name' path =
   let
@@ -103,17 +106,13 @@ serviceMessage name' path =
   in
     { name, nodeId, parentNodeId }
 
-withDuration :: Number ->  ServiceMessage () ->WithDuration
+withDuration :: Number -> ServiceMessage () -> WithDuration
 withDuration duration { name, nodeId, parentNodeId } =
-   { name, nodeId, parentNodeId, duration }
+  { name, nodeId, parentNodeId, duration }
 
-withMessage :: String ->  ServiceMessage () -> WithMessage
+withMessage :: String -> ServiceMessage () -> WithMessage
 withMessage message { name, nodeId, parentNodeId } =
-   { name, nodeId, parentNodeId, message }
-
-type WithMessage = ServiceMessage (message :: String)
-type WithDuration = ServiceMessage (duration :: Number)
-
+  { name, nodeId, parentNodeId, message }
 
 idFromPath :: Path -> String
 idFromPath path = path
@@ -137,8 +136,10 @@ teamcityReporter = defaultReporter Map.empty case _ of
     tellLn $ testIgnored attributes
     tellLn $ testFinished attributes
   Event.TestEnd path name' (Success _ (Milliseconds millies)) ->
-    tellLn $ testFinishedIn (serviceMessage name' path
-        # withDuration millies)
+    tellLn $ testFinishedIn
+      ( serviceMessage name' path
+          # withDuration millies
+      )
   Event.TestEnd path name' (Failure error) -> do
     let attributes = serviceMessage name' path # withMessage (show error)
     tellLn $ testFailed attributes

--- a/src/Test/Spec/Reporter/TeamCity.purs
+++ b/src/Test/Spec/Reporter/TeamCity.purs
@@ -96,9 +96,8 @@ type WithMessage = ServiceMessage (message :: String)
 type WithDuration = ServiceMessage (duration :: Number)
 
 serviceMessage :: String -> Path -> ServiceMessage ()
-serviceMessage name' path =
+serviceMessage name path =
   let
-    name = name'
     nodeId = idFromPath path
     parentNodeId = parentSuite path
       <#> _.path

--- a/src/Test/Spec/Reporter/TeamCity.purs
+++ b/src/Test/Spec/Reporter/TeamCity.purs
@@ -5,10 +5,10 @@ import Prelude
 
 import Control.Monad.State (get, modify)
 import Data.Array (intercalate) as Array
+import Data.Foldable (for_)
 import Data.Int (trunc)
 import Data.Map.Internal as Map
 import Data.Maybe (Maybe, fromMaybe)
-import Data.Maybe (fromMaybe) as Maybe
 import Data.Newtype (unwrap)
 import Data.String.Regex (replace') as Regex
 import Data.String.Regex.Flags (global) as Regex
@@ -114,8 +114,9 @@ teamcityReporter = defaultReporter Map.empty case _ of
     void $ modify $ Map.insert path name
     tellLn $ testSuiteStarted $ serviceMessage name path
   Event.SuiteEnd path -> do
-    name <- get <#> Map.lookup path <#> Maybe.fromMaybe ""
-    tellLn $ testSuiteFinished $ serviceMessage name path
+    maybeName <- get <#> Map.lookup path
+    for_ maybeName \name -> do
+      tellLn $ testSuiteFinished $ serviceMessage name path
   Event.Test _ path name -> do
     tellLn $ testStarted $ serviceMessage name path
   Event.Pending path name -> do

--- a/src/Test/Spec/Reporter/TeamCity.purs
+++ b/src/Test/Spec/Reporter/TeamCity.purs
@@ -42,8 +42,8 @@ teamcity name properties = "##teamcity[" <> body <> "]"
   body = name : (properties <#> renderProperty) # Array.intercalate " "
   renderProperty (key /\ value) = key <> "='" <> escape value <> "'"
 
-message :: forall a. String -> ServiceMessage a -> String
-message event { name, nodeId, parentNodeId } = teamcity event
+teamcity' :: forall a. String -> ServiceMessage a -> String
+teamcity' event { name, nodeId, parentNodeId } = teamcity event
   [ "name" /\ name
   , "nodeId" /\ nodeId
   , "parentNodeId" /\ (fromMaybe "0" parentNodeId)
@@ -53,19 +53,19 @@ testCount :: Int -> String
 testCount count = teamcity "testCount" [ "count" /\ show count ]
 
 testSuiteStarted :: forall a. ServiceMessage a -> String
-testSuiteStarted = message "testSuiteStarted"
+testSuiteStarted = teamcity' "testSuiteStarted"
 
 testSuiteFinished :: forall a. ServiceMessage a -> String
-testSuiteFinished = message "testSuiteFinished"
+testSuiteFinished = teamcity' "testSuiteFinished"
 
 testStarted :: forall a. ServiceMessage a -> String
-testStarted = message "testStarted"
+testStarted = teamcity' "testStarted"
 
 testIgnored :: forall a. ServiceMessage a -> String
-testIgnored = message "testIgnored"
+testIgnored = teamcity' "testIgnored"
 
 testFinished :: forall a. ServiceMessage a -> String
-testFinished = message "testFinished"
+testFinished = teamcity' "testFinished"
 
 testFinishedIn :: WithDuration -> String
 testFinishedIn { name, nodeId, parentNodeId, duration } =
@@ -130,7 +130,7 @@ teamcityReporter = defaultReporter Map.empty case _ of
     name <- get <#> Map.lookup path <#> Maybe.fromMaybe ""
     tellLn $ testSuiteFinished $ serviceMessage name path
   Event.Test _ path name -> do
-    tellLn $ message "testStarted" $ serviceMessage name path
+    tellLn $ teamcity' "testStarted" $ serviceMessage name path
   Event.Pending path name -> do
     let attributes = serviceMessage name path
     tellLn $ testStarted attributes

--- a/test/Test/Spec/Reporter/TeamCitySpec.purs
+++ b/test/Test/Spec/Reporter/TeamCitySpec.purs
@@ -2,17 +2,17 @@ module Test.Spec.Reporter.TeamCitySpec (teamcitySpec) where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
-import Data.Tuple.Nested ((/\))
 import Test.Spec.Reporter.TeamCity as TC
 
 teamcitySpec :: Spec Unit
 teamcitySpec = describe "Team City Reporter" do
   it "can print Team City Service Messages" do
-    TC.teamcity "testStarted" [ "name" /\ "test.name" ]
-      # shouldEqual "##teamcity[testStarted name='test.name']"
+    TC.teamcity "testStarted" { name: "test.name", nodeId: "null", parentNodeId: Nothing }
+      # shouldEqual "##teamcity[testStarted name='test.name' nodeId='null' parentNodeId='0']"
   it "escapes property values" do
-    TC.teamcity "testStarted" [ "name" /\ "|test\n\r[nam'e]" ]
-      # shouldEqual "##teamcity[testStarted name='||test|n|r|[nam|'e|]']"
+    TC.teamcity "testStarted" { name: "|test\n\r[nam'e]", nodeId: "null", parentNodeId: Nothing }
+      # shouldEqual "##teamcity[testStarted name='||test|n|r|[nam|'e|]' nodeId='null' parentNodeId='0']"
 


### PR DESCRIPTION
The teamcity reporter now reports id for the node and its parent so that the tool reading the output don't need to ques anymore through nesting. This means that it should have full support for parallel test runs.

bellow is a example of the tests running in intellij with the new changes

https://user-images.githubusercontent.com/72190/211170814-3ea8f6b1-21db-4ab0-bd46-7284ffcc5b44.mp4

