### PR TITLE
Support for filtering the test tree

### DIFF
--- a/integration-tests/cases/01-all-passing/output.txt
+++ b/integration-tests/cases/01-all-passing/output.txt
@@ -1,12 +1,12 @@
- [32m✓︎ [0m[2mone[0m
- two
-  [32m✓︎ [0m[2mfirst[0m
-  [32m✓︎ [0m[2msecond[0m
-  [32m✓︎ [0m[2mthird[0m
- three
-  1
-   [32m✓︎ [0m[2muno[0m
-   [32m✓︎ [0m[2mdos[0m
-  2
-   [32m✓︎ [0m[2mein[0m
+[32m✓︎ [0m[2mone[0m
+two
+ [32m✓︎ [0m[2mfirst[0m
+ [32m✓︎ [0m[2msecond[0m
+ [32m✓︎ [0m[2mthird[0m
+three
+ 1
+  [32m✓︎ [0m[2muno[0m
+  [32m✓︎ [0m[2mdos[0m
+ 2
+  [32m✓︎ [0m[2mein[0m
 [32m7 passing[0m

--- a/integration-tests/cases/02-all-failing/output.txt
+++ b/integration-tests/cases/02-all-failing/output.txt
@@ -1,13 +1,13 @@
- [31m1) one[0m
- two
-  [31m2) first[0m
-  [31m3) second[0m
- three
-  1
-   [31m4) uno[0m
-   [31m5) dos[0m
-  2
-   [31m6) ein[0m
+[31m1) one[0m
+two
+ [31m2) first[0m
+ [31m3) second[0m
+three
+ 1
+  [31m4) uno[0m
+  [31m5) dos[0m
+ 2
+  [31m6) ein[0m
 [31m6 failed[0m
 
 1) one

--- a/integration-tests/cases/03-some-passing/output.txt
+++ b/integration-tests/cases/03-some-passing/output.txt
@@ -1,13 +1,13 @@
- [31m1) one[0m
- two
-  [32m✓︎ [0m[2mfirst[0m
-  [31m2) second[0m
- three
-  1
-   [31m3) uno[0m
-   [32m✓︎ [0m[2mdos[0m
-  2
-   [32m✓︎ [0m[2mein[0m
+[31m1) one[0m
+two
+ [32m✓︎ [0m[2mfirst[0m
+ [31m2) second[0m
+three
+ 1
+  [31m3) uno[0m
+  [32m✓︎ [0m[2mdos[0m
+ 2
+  [32m✓︎ [0m[2mein[0m
 [32m3 passing[0m
 [31m3 failed[0m
 

--- a/integration-tests/cases/04-fail-fast-with-timeout/output.txt
+++ b/integration-tests/cases/04-fail-fast-with-timeout/output.txt
@@ -1,5 +1,5 @@
- [32m✓︎ [0m[2mpasses quickly[0m
- [31m1) times out[0m
+[32m✓︎ [0m[2mpasses quickly[0m
+[31m1) times out[0m
 [31m1 failed[0m
 
 1) times out

--- a/integration-tests/cases/05-fail-fast-due-to-test-failure/output.txt
+++ b/integration-tests/cases/05-fail-fast-due-to-test-failure/output.txt
@@ -1,5 +1,5 @@
- [32m✓︎ [0m[2mpasses[0m
- [31m1) fails[0m
+[32m✓︎ [0m[2mpasses[0m
+[31m1) fails[0m
 [31m1 failed[0m
 
 1) fails

--- a/src/Test/Spec/Config.purs
+++ b/src/Test/Spec/Config.purs
@@ -1,5 +1,6 @@
 module Test.Spec.Config
   ( Config
+  , TreeFilter(..)
   , defaultConfig
   )
   where
@@ -8,6 +9,7 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Milliseconds(..))
+import Test.Spec (SpecTree)
 
 type Config =
   { slow :: Milliseconds
@@ -23,7 +25,13 @@ type Config =
 
   , failFast :: Boolean
   -- ^ When `true`, first failed test stops the whole run.
+
+  , filterTree :: TreeFilter
+  -- ^ The spec tree goes through this function before execution. Can be used to
+  -- filter out test cases, rearrange, annotate, etc.
   }
+
+newtype TreeFilter = TreeFilter (∀ g i. Array (SpecTree g i) -> Array (SpecTree g i))
 
 defaultConfig :: Config
 defaultConfig =
@@ -31,4 +39,5 @@ defaultConfig =
   , timeout: Just $ Milliseconds 2000.0
   , exit: true
   , failFast: false
+  , filterTree: TreeFilter identity
   }

--- a/src/Test/Spec/Reporter/Console.purs
+++ b/src/Test/Spec/Reporter/Console.purs
@@ -48,7 +48,7 @@ consoleReporter = defaultReporter initialState $ defaultUpdate
       _ -> pure unit
   }
 
-printSummary :: forall m. MonadWriter String m => Array (Tree Void Result) -> m Unit
+printSummary :: ∀ n m. MonadWriter String m => Array (Tree n Void Result) -> m Unit
 printSummary = Summary.summarize >>> \(Count {passed, failed, pending}) -> do
   tellLn ""
   tellLn $ styled Style.bold "Summary"

--- a/src/Test/Spec/Runner/Event.purs
+++ b/src/Test/Spec/Runner/Event.purs
@@ -22,7 +22,7 @@ data Event
   | Test Execution Path Name
   | TestEnd Path Name Result
   | Pending Path Name
-  | End (Array (Tree Void Result))
+  | End (Array (Tree String Void Result))
 
 instance showEvent :: Show Event where
   show = case _ of

--- a/src/Test/Spec/Summary.purs
+++ b/src/Test/Spec/Summary.purs
@@ -21,12 +21,12 @@ instance semigroupCount :: Semigroup Summary where
 instance monoidCount :: Monoid Summary where
   mempty = Count zero
 
-summarize :: forall a. Array (Tree a Result) -> Summary
+summarize :: ∀ n a. Array (Tree n a Result) -> Summary
 summarize = foldMap case _ of
   (Leaf _ (Just (Success _ _))) -> Count { passed: 1, failed: 0, pending: 0 }
   (Leaf _ (Just (Failure _))) -> Count { passed: 0, failed: 1, pending: 0 }
   (Leaf _ Nothing) -> Count { passed: 0, failed: 0, pending: 1 }
   (Node _ dgs) -> summarize dgs
 
-successful :: forall a. Array (Tree a Result) -> Boolean
+successful :: ∀ n a. Array (Tree n a Result) -> Boolean
 successful groups = (un Count $ summarize groups).failed == 0

--- a/src/Test/Spec/Tree.purs
+++ b/src/Test/Spec/Tree.purs
@@ -1,49 +1,57 @@
 module Test.Spec.Tree
-  ( Tree(..)
+  ( ActionWith
   , Item(..)
-  , ActionWith
-  , bimapTree
-  , countTests
-  , isAllParallelizable
-  , discardUnfocused
-  , modifyAroundAction
-  , PathItem(..)
   , Path
-  , parentSuiteName
+  , PathItem(..)
+  , Tree(..)
+  , annotateWithPaths
+  , bimapTreeWithPaths
+  , countTests
+  , discardUnfocused
+  , filterTree
+  , filterTrees
+  , isAllParallelizable
+  , mapTreeAnnotations
+  , modifyAroundAction
   , parentSuite
-  ) where
+  , parentSuiteName
+  )
+  where
 
 import Prelude
 
 import Control.Monad.State (execState)
 import Control.Monad.State as State
-import Data.Array (mapMaybe, snoc)
+import Data.Array (mapMaybe, mapWithIndex, snoc)
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NEA
-import Data.Bifunctor (class Bifunctor)
+import Data.Bifunctor (class Bifunctor, bimap, lmap)
 import Data.Either (Either, either)
 import Data.Foldable (class Foldable, all, foldMapDefaultL, foldl, foldr)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, un)
 import Data.Traversable (for, for_)
+import Data.Tuple.Nested (type (/\), (/\))
 
-data Tree c a
-  = Node (Either String c) (Array (Tree c a))
-  | Leaf String (Maybe a)
+data Tree n c a
+  = Node (Either n c) (Array (Tree n c a))
+  | Leaf n (Maybe a)
 
-instance showGroup :: (Show c, Show a) => Show (Tree c a) where
+derive instance Functor (Tree n c)
+
+instance (Show c, Show a, Show n) => Show (Tree n c a) where
   show (Node nc xs) = "(Node " <> show nc <> " " <> show xs <> ")"
   show (Leaf name t) = "(Leaf " <> show name <> " " <> show t <> ")"
 
-instance eqGroup :: (Eq c, Eq a) => Eq (Tree c a) where
+instance (Eq c, Eq a, Eq name) => Eq (Tree name c a) where
   eq (Node nc1 xs1) (Node nc2 xs2) = nc1 == nc2 && xs1 == xs2
   eq (Leaf n1 t1) (Leaf n2 t2) = n1 == n2 && t1 == t2
   eq _ _ = false
 
-bimapTree :: forall a b c d. (Array String -> a -> b) -> (NonEmptyArray String -> c -> d) -> Tree a c -> Tree b d
-bimapTree g f = go []
+bimapTreeWithPaths :: ∀ a b c d n. (Array n -> a -> b) -> (NonEmptyArray n -> c -> d) -> Tree n a c -> Tree n b d
+bimapTreeWithPaths g f = go []
   where
-  go :: Array String -> Tree a c -> Tree b d
+  go :: Array n -> Tree n a c -> Tree n b d
   go namePath spec = case spec of
     Node d xs ->
       let
@@ -52,10 +60,12 @@ bimapTree g f = go []
         Node (map (g namePath') d) (map (go namePath') xs)
     Leaf n item -> Leaf n (map (f $ NEA.snoc' namePath n) item)
 
-instance treeBifunctor :: Bifunctor Tree where
-  bimap g f = bimapTree (const g) (const f)
+instance Bifunctor (Tree n) where
+  bimap g f tree = case tree of
+    Node c cs -> Node (g <$> c) $ bimap g f <$> cs
+    Leaf n a -> Leaf n $ f <$> a
 
-instance treeFoldable :: Foldable (Tree c) where
+instance Foldable (Tree n c) where
   foldr f i (Leaf _ a) = maybe i (\a' -> f a' i) a
   foldr f i (Node _ as) = foldr (\a i' -> foldr f i' a) i as
   foldl f i (Leaf _ a) = maybe i (\a' -> f i a') a
@@ -80,15 +90,47 @@ instance itemEq :: Eq (Item m a) where
   eq (Item a) (Item b) =
     a.isFocused == b.isFocused && a.isParallelizable == b.isParallelizable
 
+annotateWithPaths :: ∀ c a. Array (Tree String c a) -> Array (Tree (String /\ Path) c a)
+annotateWithPaths = mapWithIndex $ go []
+  where
+    go path index = case _ of
+      Node c children ->
+        let name = either Just (const Nothing) c
+            nextPath = path <> [PathItem { index, name }]
+        in
+          Node (c # lmap (_ /\ path)) (mapWithIndex (go nextPath) children)
+
+      Leaf name item ->
+        Leaf (name /\ path) item
+
+mapTreeAnnotations :: ∀ n m c a. (n -> m) -> Tree n c a -> Tree m c a
+mapTreeAnnotations f = case _ of
+  Node c cs -> Node (lmap f c) $ mapTreeAnnotations f <$> cs
+  Leaf n a -> Leaf (f n) a
+
+filterTrees :: ∀ n c a. (n -> Maybe a -> Boolean) -> Array (Tree n c a) -> Array (Tree n c a)
+filterTrees f = mapMaybe $ filterTree f
+
+filterTree :: ∀ n c a. (n -> Maybe a -> Boolean) -> Tree n c a -> Maybe (Tree n c a)
+filterTree f = case _ of
+  Node c children ->
+    case mapMaybe (filterTree f) children of
+      [] -> Nothing
+      cs -> Just $ Node c cs
+
+  Leaf n a
+    | f n a -> Just $ Leaf n a
+    | otherwise -> Nothing
+
 -- | Count the total number of tests in a spec
-countTests :: forall c t. Array (Tree c t) -> Int
+countTests :: ∀ n c t. Array (Tree n c t) -> Int
 countTests g = execState (for g go) 0
   where
   go (Node _ xs) = for_ xs go
   go (Leaf _ _) = State.modify_ (_ + 1)
 
 -- | Return true if all items in the tree are parallelizable
-isAllParallelizable :: forall c m a. Tree c (Item m a) -> Boolean
+isAllParallelizable :: ∀ n c m a. Tree n c (Item m a) -> Boolean
 isAllParallelizable = case _ of
   Node _ xs -> all isAllParallelizable xs
   Leaf _ x -> x == Nothing || (x >>= un Item >>> _.isParallelizable) == Just true
@@ -96,20 +138,17 @@ isAllParallelizable = case _ of
 -- | If there is at least one focused element, all paths which don't
 -- | lead to a focused element will be remove. otherwise input will
 -- | be returned as unchanged.
-discardUnfocused :: forall c m a. Array (Tree c (Item m a)) -> Array (Tree c (Item m a))
-discardUnfocused ts = case mapMaybe findFocus ts of
-  [] -> ts
-  r -> r
+discardUnfocused :: ∀ n c m a. Array (Tree n c (Item m a)) -> Array (Tree n c (Item m a))
+discardUnfocused ts =
+  case filterTrees isFocused ts of
+    [] -> ts
+    r -> r
   where
-  findFocus :: Tree c (Item m a) -> Maybe (Tree c (Item m a))
-  findFocus (Node n ts') = case mapMaybe findFocus ts' of
-    [] -> Nothing
-    r -> Just $ Node n r
-  findFocus t@(Leaf _ (Just (Item { isFocused }))) = if isFocused then Just t else Nothing
-  findFocus (Leaf _ Nothing) = Nothing
+    isFocused _ (Just (Item i)) = i.isFocused
+    isFocused _ Nothing = false
 
 -- | Modify around action of an Item
-modifyAroundAction :: forall g a b. (ActionWith g a -> ActionWith g b) -> Item g a -> Item g b
+modifyAroundAction :: ∀ g a b. (ActionWith g a -> ActionWith g b) -> Item g a -> Item g b
 modifyAroundAction action (Item item) = Item $ item
   { example = \aroundAction -> item.example (aroundAction <<< action)
   }

--- a/test/Integration.purs
+++ b/test/Integration.purs
@@ -23,14 +23,14 @@ import Node.FS.Stats (isDirectory)
 import Node.OS (tmpdir)
 import Node.Process (cwd)
 import Node.Stream as Stream
-import Test.Spec (SpecT, afterAll, describe, focus, it)
+import Test.Spec (SpecT, afterAll, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
 -- | Reads the contents of `/integration-tests/cases` and turns each
 -- | subdirectory into a test case. See `/integration-tests/cases/README` for
 -- | more details.
 integrationSpecs :: SpecT Aff Unit Aff Unit
-integrationSpecs = focus do
+integrationSpecs = do
   { runFile, cleanupEnvironment } <- liftEffect $ prepareEnvironment { debug: false }
 
   afterAll (\_ -> cleanupEnvironment) $


### PR DESCRIPTION
* The `Tree` type now has an extra parameter denoting annotation of each node. Previously this was always `String` (meaning name), now it's a parameter.
* Extracted the logic of computing paths from `run_` and `printFailures`, named it `annotateWithPaths`. Replaces node names with pairs name+path.
* Added a generalized `filterTree` function, rephrased `discradUnfocused` in terms of `filterTree`.
* New config parameter - `filterTree`. The runner passes the test tree through it before execution.