### PR TITLE
Better support for fail-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ctags:
 		> tags
 
 build-example: $(OUTPUT)
-	npx spago bundle-app --path $(example) --to $(OUTPUT)/example.js --minify --platform=node
+	npx spago bundle-app --path $(example) --to $(OUTPUT)/example.js --minify
 
 run-example: build-example
 	npx spago run --path $(example)

--- a/integration-tests/cases/04-fail-fast-with-timeout/output.txt
+++ b/integration-tests/cases/04-fail-fast-with-timeout/output.txt
@@ -1,5 +1,7 @@
 [32m✓︎ [0m[2mpasses quickly[0m
 [31m1) times out[0m
+[32m1 passing[0m
+[36m1 pending[0m
 [31m1 failed[0m
 
 1) times out

--- a/integration-tests/cases/05-fail-fast-due-to-test-failure/output.txt
+++ b/integration-tests/cases/05-fail-fast-due-to-test-failure/output.txt
@@ -1,5 +1,7 @@
 [32m✓︎ [0m[2mpasses[0m
 [31m1) fails[0m
+[32m1 passing[0m
+[36m1 pending[0m
 [31m1 failed[0m
 
 1) fails

--- a/spago.dhall
+++ b/spago.dhall
@@ -25,6 +25,7 @@
   , "parallel"
   , "pipes"
   , "prelude"
+  , "refs"
   , "strings"
   , "tailrec"
   , "transformers"

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -30,6 +30,7 @@ runnerSpec =
               [ Node (Left "b") [ Leaf "works" $ Just false ]
               ]
             ]
+
         it "collects \"it\" and \"pending\" with shared Describes" do
           runSpecFocused sharedDescribeTest `shouldEqual`
             [ Node (Left "a")
@@ -37,6 +38,7 @@ runnerSpec =
               , Node (Left "c") [ Leaf "also works" $ Just false ]
               ]
             ]
+
         it "filters using \"only\" modifier on \"describe\" block" do
           runSpecFocused describeOnlyTest `shouldEqual`
             [ Node (Left "a")
@@ -44,21 +46,25 @@ runnerSpec =
               , Node (Left "c") [ Leaf "also works" $ Just true ]
               ]
             ]
+
         it "filters using \"only\" modifier on nested \"describe\" block" do
           runSpecFocused describeOnlyNestedTest `shouldEqual`
             [ Node (Left "a")
               [ Node (Left "b") [ Leaf "works" $ Just true ]
               ]
             ]
+
         it "filters using \"only\" modifier on \"it\" block" do
           runSpecFocused itOnlyTest `shouldEqual`
             [ Node (Left "a")
               [ Node (Left "b") [ Leaf "works" $ Just true ]
               ]
             ]
+
         it "supports async" do
           res <- delay (Milliseconds 10.0) *> pure 1
           res `shouldEqual` 1
+
         it "supports fail-fast" do
           let config = defaultConfig { exit = false, failFast = true }
           res <- un Identity $ runSpecT config [] $
@@ -68,11 +74,15 @@ runnerSpec =
               it "succeeds" $ 1 `shouldEqual` 1
               it "fails again" $ 1 `shouldEqual` 2
 
-          case res of
-            [Leaf "A test fails" (Just (Failure _))] ->
-              pure unit
-            unexpectedResult ->
-              fail $ "Got unexpected result: " <> show unexpectedResult
+          (map mapSuccess <$> res) `shouldEqual`
+            [ Node (Left "A test")
+              [ Leaf "fails" (Just false)
+              , Leaf "also fails" Nothing
+              , Leaf "succeeds" Nothing
+              , Leaf "fails again" Nothing
+              ]
+            ]
+
         it "supports tree filtering" do
           let config = defaultConfig
                 { exit = false


### PR DESCRIPTION
The original implementation in #137 was a bit lazy: due to accidental complexity, it was very hard to return the whole test tree if the execution was stopped on first failure. However, down the stack it turned out that we do need the full tree after all, so this PR makes it happen. 

Instead of a downstream filtering pipe, the `failFast` option is now checked during the tree traversal, and a mutable cell is used to indicate when the execution ought to stop. When that mutable flag is set, the tree traversal itself still runs to the end, producing the full tree, even though the actual example execution gets skipped. Accordingly, in that case, skipped tests will show up in the results as "pending".

The mutable cell is used instead of a, say, `StateT`, because of parallelization, which doesn't support `StateT`.