### PR TITLE
Console reporter should look at full path when deciding whether to print suite

### DIFF
--- a/integration-tests/cases/issue-144-console-reporter-single-level-nesting/Main.purs
+++ b/integration-tests/cases/issue-144-console-reporter-single-level-nesting/Main.purs
@@ -1,0 +1,19 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Aff (launchAff_)
+import Test.Spec (describe, it)
+import Test.Spec.Config (defaultConfig)
+import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Runner (runSpec')
+
+main :: Effect Unit
+main = launchAff_ $ runSpec' defaultConfig [consoleReporter] do
+  describe "A" do
+    it "should be under A" (pure unit)
+  describe "B" do
+    it "should be under B" (pure unit)
+  describe "C" do
+    it "should be under C" (pure unit)

--- a/integration-tests/cases/issue-144-console-reporter-single-level-nesting/output.txt
+++ b/integration-tests/cases/issue-144-console-reporter-single-level-nesting/output.txt
@@ -1,0 +1,9 @@
+[1;35mA[0m
+  [32m✓︎ [0m[2mshould be under A[0m
+[1;35mB[0m
+  [32m✓︎ [0m[2mshould be under B[0m
+[1;35mC[0m
+  [32m✓︎ [0m[2mshould be under C[0m
+
+[1mSummary[0m
+[2m3/3 tests passed[0m

--- a/src/Test/Spec/Reporter/Console.purs
+++ b/src/Test/Spec/Reporter/Console.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad.State (class MonadState, get, put)
 import Control.Monad.Writer (class MonadWriter)
-import Data.Foldable (for_, intercalate)
+import Data.Foldable (intercalate)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
 import Data.Map as Map
@@ -20,7 +20,7 @@ import Test.Spec.Style (styled)
 import Test.Spec.Style as Style
 import Test.Spec.Summary (Summary(..))
 import Test.Spec.Summary as Summary
-import Test.Spec.Tree (Path, Tree, parentSuite, parentSuiteName)
+import Test.Spec.Tree (Path, Tree, parentSuiteName)
 
 type State = { runningItems :: Map Path RunningItem, lastPrintedSuitePath :: Maybe Path}
 
@@ -88,14 +88,13 @@ print
   -> PrintAction
   -> m Unit
 print path a = do
-  for_ (parentSuite path) \suite -> do
-    s <- get
-    case s.lastPrintedSuitePath of
-      Just p | p == suite.path -> pure unit
-      _ -> do
-        tellLn $ styled (Style.bold <> Style.magenta)
-          $ intercalate " » " (parentSuiteName suite.path <> [suite.name])
-        put s{lastPrintedSuitePath = Just suite.path}
+  s <- get
+  case s.lastPrintedSuitePath of
+    Just p | p == path -> pure unit
+    _ -> do
+      tellLn $ styled (Style.bold <> Style.magenta)
+        $ intercalate " » " (parentSuiteName path)
+      put s { lastPrintedSuitePath = Just path }
   case a of
     PrintTest name (Success _ _) -> do
       tellLn $ "  " <> styled Style.green "✓︎ " <> styled Style.dim name


### PR DESCRIPTION
Fixes #144 

When printing the just-finished test, `consoleReporter` decides whether to print the suite name before it or not. To make the decision, the reporter looks at the last suite name it printed: if it's different from the current one, print it, otherwise - skip.

The problem was, it wasn't comparing the full suite name, but only the N-1 prefix of it. As a result, it required a minimum of two levels of suites change from test to test in order to print the suite.