### PR TITLE
Fix Reporter.Base.defaultUpdate handling of parallel execution

### DIFF
--- a/integration-tests/cases/issue-149-async-tests/Main.purs
+++ b/integration-tests/cases/issue-149-async-tests/Main.purs
@@ -1,0 +1,33 @@
+module Test.Main where
+
+import Prelude
+
+import Data.Time.Duration (Milliseconds(..))
+import Effect (Effect)
+import Effect.Aff (delay)
+import Test.Spec (Spec, describe, it, parallel)
+import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Runner.Node (runSpecAndExitProcess)
+
+main :: Effect Unit
+main = runSpecAndExitProcess [consoleReporter] spec
+
+spec :: Spec Unit
+spec =
+  describe "async delayed tests" $ parallel do
+    it "test1" do
+      delay (Milliseconds 100.0)
+      true `shouldEqual` true
+    it "test2" do
+      delay (Milliseconds 100.0)
+      true `shouldEqual` true
+    it "test3" do
+      delay (Milliseconds 100.0)
+      true `shouldEqual` true
+    it "test4" do
+      delay (Milliseconds 100.0)
+      true `shouldEqual` false
+    it "test5" do
+      delay (Milliseconds 100.0)
+      true `shouldEqual` true

--- a/integration-tests/cases/issue-149-async-tests/output.txt
+++ b/integration-tests/cases/issue-149-async-tests/output.txt
@@ -1,0 +1,11 @@
+async delayed tests
+  ✓︎ test1
+  ✓︎ test2
+  ✓︎ test3
+  ✗ test4:
+
+  true ≠ false
+  ✓︎ test5
+
+Summary
+4/5 tests passed

--- a/src/Test/Spec/Reporter/Dot.purs
+++ b/src/Test/Spec/Reporter/Dot.purs
@@ -17,9 +17,9 @@ type DotReporterConfig = { width :: Int }
 
 dotReporter :: DotReporterConfig -> Reporter
 dotReporter { width } = defaultReporter (-1) case _ of
-  Event.TestEnd _ _ (Success speed _) -> wrap $ styled (Speed.toStyle speed) "."
-  Event.TestEnd _ _ (Failure _) -> wrap $ styled Style.red "!"
-  Event.Pending _ _ -> wrap $ styled Style.dim ","
+  Event.TestEnd _ (Success speed _) -> wrap $ styled (Speed.toStyle speed) "."
+  Event.TestEnd _ (Failure _) -> wrap $ styled Style.red "!"
+  Event.Pending _ -> wrap $ styled Style.dim ","
   Event.End _ -> tellLn ""
   _ -> pure unit
   where

--- a/src/Test/Spec/Reporter/Tap.purs
+++ b/src/Test/Spec/Reporter/Tap.purs
@@ -7,6 +7,7 @@ import Data.Maybe (Maybe(..))
 import Data.String (Pattern(Pattern), joinWith, split)
 import Data.String.Regex as Regex
 import Data.String.Regex.Unsafe (unsafeRegex)
+import Data.Tuple.Nested ((/\))
 import Effect.Exception as Error
 import Test.Spec.Console (tellLn)
 import Test.Spec.Reporter.Base (defaultReporter)
@@ -22,15 +23,15 @@ tapReporter :: Reporter
 tapReporter = defaultReporter 1 case _ of
   Event.Start nTests ->
     tellLn $ "1.." <> show nTests
-  Event.Pending _ name -> do
+  Event.Pending (_ /\ name) -> do
     n <- get
     tellLn $ "ok " <> show n <> " " <> (escTitle name) <> " # SKIP -"
     modify_ (_ + 1)
-  Event.TestEnd _ name (Success _ _) -> do
+  Event.TestEnd (_ /\ name) (Success _ _) -> do
     n <- get
     tellLn $ "ok " <> show n <> " " <> (escTitle name)
     modify_ (_ + 1)
-  Event.TestEnd _ name (Failure err) -> do
+  Event.TestEnd (_ /\ name) (Failure err) -> do
     n <- get
     tellLn $ "not ok " <> show n <> " " <> (escTitle name)
     tellLn $ escMsg $ Error.message err

--- a/src/Test/Spec/Runner/Event.purs
+++ b/src/Test/Spec/Runner/Event.purs
@@ -2,12 +2,10 @@ module Test.Spec.Runner.Event where
 
 import Prelude
 
+import Data.Tuple.Nested ((/\))
 import Test.Spec (Tree)
 import Test.Spec.Result (Result)
-import Test.Spec.Tree (Path)
-
-type Name = String
-type NumberOfTests = Int
+import Test.Spec.Tree (NumberOfTests, TestLocator)
 
 data Execution = Parallel | Sequential
 instance showExecution :: Show Execution where
@@ -17,19 +15,19 @@ instance showExecution :: Show Execution where
 
 data Event
   = Start NumberOfTests
-  | Suite Execution Path Name
-  | SuiteEnd Path
-  | Test Execution Path Name
-  | TestEnd Path Name Result
-  | Pending Path Name
+  | Suite Execution TestLocator
+  | SuiteEnd TestLocator
+  | Test Execution TestLocator
+  | TestEnd TestLocator Result
+  | Pending TestLocator
   | End (Array (Tree String Void Result))
 
 instance showEvent :: Show Event where
   show = case _ of
     Start n -> "Start " <> show n
-    Suite e path name -> "Suite " <> show e <> show path <> ": " <> name
-    SuiteEnd path -> "SuiteEnd " <> show path
-    Test e path name -> "Test " <> show e <> show path <> " " <> name
-    TestEnd path name res -> "TestEnd " <> show path <> " " <> name <> ": " <> show res
-    Pending path name -> "Pending " <> show path <> " " <> name
+    Suite e (path /\ name) -> "Suite " <> show e <> show path <> ": " <> name
+    SuiteEnd (path /\ name) -> "SuiteEnd " <> show path <> ": " <> name
+    Test e (path /\ name) -> "Test " <> show e <> show path <> " " <> name
+    TestEnd (path /\ name) res -> "TestEnd " <> show path <> " " <> name <> ": " <> show res
+    Pending (path /\ name) -> "Pending " <> show path <> " " <> name
     End results -> "End " <> show results

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -9,7 +9,7 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
 import Data.String as Str
 import Data.Time.Duration (Milliseconds(..))
-import Data.Tuple (fst)
+import Data.Tuple (snd)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (delay)
 import Test.Spec (Item(..), Spec, SpecT, Tree(..), collect, describe, it)
@@ -17,7 +17,7 @@ import Test.Spec.Assertions (fail, shouldEqual)
 import Test.Spec.Fixtures (itOnlyTest, describeOnlyNestedTest, describeOnlyTest, sharedDescribeTest, successTest)
 import Test.Spec.Result (Result(..))
 import Test.Spec.Runner (TreeFilter(..), defaultConfig, evalSpecT)
-import Test.Spec.Tree (annotateWithPaths, filterTrees, mapTreeAnnotations, parentSuiteName)
+import Test.Spec.Tree (annotatedWithPaths, filterTrees, mapTreeAnnotations, parentSuiteName)
 
 runnerSpec :: Spec Unit
 runnerSpec =
@@ -87,13 +87,13 @@ runnerSpec =
           let config = defaultConfig
                 { exit = false
                 , filterTree = TreeFilter \trees -> trees
-                    # annotateWithPaths                     -- Give every node a path
-                    # filterTrees (\(name /\ path) _ ->     -- Use the path for filtering nodes
+                    # annotatedWithPaths                     -- Give every node a path
+                    # filterTrees (\(path /\ name) _ ->     -- Use the path for filtering nodes
                         parentSuiteName path <> [name]
                         # Str.joinWith " "
                         # Str.contains (Str.Pattern "a b")  -- Leave only nodes that have "a b" in their path somewhere
                       )
-                    <#> mapTreeAnnotations fst              -- Drop the paths from the tree
+                    <#> mapTreeAnnotations snd              -- Drop the paths from the tree
                 }
 
           res <- un Identity $ evalSpecT config [] do


### PR DESCRIPTION
Fixes #149 

It turns out reporting of parallelized tests has been broken for a while due to the `path` no longer being the full path, but only the "parent" path of the test item in question.

In this PR I am bringing a bit more standardization to this area, creating a new type `TestLocator = Path /\ Name` and converting relevant places to using it.

I'm not sure this is optimal. Perhaps `Path` alone should be used as a tree-scoped ID of a test. But this is also a bit inconsistent, because some types explicitly include the test name. Need to think about it some more. 